### PR TITLE
Graphql-import@0.6.0 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3175,7 +3175,7 @@
     },
     "@types/graphql": {
       "version": "0.12.6",
-      "resolved": "http://registry.npmjs.org/@types/graphql/-/graphql-0.12.6.tgz",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.12.6.tgz",
       "integrity": "sha512-wXAVyLfkG1UMkKOdMijVWFky39+OD/41KftzqfX1Oejd0Gm6dOIKjCihSVECg6X7PHjftxXmfOKA/d1H79ZfvQ==",
       "dev": true
     },
@@ -3224,22 +3224,6 @@
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.5.3.tgz",
       "integrity": "sha512-aDvGDAHcVfUqNmd8q4//cHAP+HGxsbChbBbuk3+kMVk5TTxfWLpQWvVN3+UPjohLnwMYN7jr6BWNn2cYNqdm7g==",
       "dev": true
-    },
-    "Base64": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.1.4.tgz",
-      "integrity": "sha1-6fbGvvVn/WNepBYqsU3TKedKpt4=",
-      "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "abab": {
       "version": "1.0.4",
@@ -4649,6 +4633,12 @@
         }
       }
     },
+    "Base64": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.1.4.tgz",
+      "integrity": "sha1-6fbGvvVn/WNepBYqsU3TKedKpt4=",
+      "dev": true
+    },
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
@@ -4902,9 +4892,9 @@
       "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "combine-source-map": "0.8.0",
         "defined": "1.0.0",
+        "JSONStream": "1.3.2",
         "safe-buffer": "5.1.2",
         "through2": "2.0.3",
         "umd": "3.0.3"
@@ -4939,7 +4929,6 @@
       "integrity": "sha1-CJo0Y69Y0OSNjNQHCz90ZU1avKk=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "assert": "1.4.1",
         "browser-pack": "6.1.0",
         "browser-resolve": "1.11.2",
@@ -4961,6 +4950,7 @@
         "https-browserify": "1.0.0",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.6",
+        "JSONStream": "1.3.2",
         "labeled-stream-splicer": "2.0.1",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -8171,6 +8161,15 @@
           "dev": true,
           "optional": true
         },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -8179,15 +8178,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -8550,9 +8540,9 @@
       }
     },
     "graphql-import": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.5.2.tgz",
-      "integrity": "sha512-gvgtbdBUCVfztcjZN0IMf8lvewSgfM84vCRHsqP+hmZViHjpjrIkvmq0wRFkEjLXisxKk0T5Ah+XUp2Rq24Rkw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.6.0.tgz",
+      "integrity": "sha512-S6Aj4pTzehCwyh7hKUKlWLgE6soDdW/T6JPePC16exzFDNdZHXRj7lqv75yMWJCkBY0pBtWicMLinb4ni6QRyg==",
       "dev": true,
       "requires": {
         "lodash": "4.17.10"
@@ -9182,10 +9172,10 @@
       "integrity": "sha512-R3sidKJr3SsggqQQ5cEwQb3pWG8RNx0UnpyeiOSR6jorRIeAOzH2gkTWnNdMnyRiVbjrG047K7UCtlMkQ1Mo9w==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "combine-source-map": "0.8.0",
         "concat-stream": "1.6.2",
         "is-buffer": "1.1.6",
+        "JSONStream": "1.3.2",
         "lexical-scope": "1.2.0",
         "path-is-absolute": "1.0.1",
         "process": "0.11.10",
@@ -10975,6 +10965,16 @@
       "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "jsonwebtoken": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
@@ -12199,7 +12199,6 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
@@ -12207,6 +12206,7 @@
         "detective": "4.7.1",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
+        "JSONStream": "1.3.2",
         "parents": "1.0.1",
         "readable-stream": "2.3.6",
         "resolve": "1.7.1",
@@ -12979,7 +12979,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -15350,6 +15350,15 @@
       "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "string-argv": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
@@ -15392,15 +15401,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.2"
       }
     },
     "stringify-object": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.7.0",
     "graphql": "^0.13.2",
-    "graphql-import": "^0.5.0",
+    "graphql-import": "^0.6.0",
     "graphql-tools": "^2.24.0",
     "husky": "^0.14.3",
     "jest": "22.4.3",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -3831,6 +3831,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3839,14 +3847,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4094,9 +4094,10 @@
       }
     },
     "graphql-import": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.5.0.tgz",
-      "integrity": "sha512-Sv9OjGh2Cj52By83e/0ky6LlRc9UW0aCu+VFHJcxwoGaSToTVoDU0Iacsyp7NwhXdwcuRp2VIj21tiJe00c07Q==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.6.0.tgz",
+      "integrity": "sha512-S6Aj4pTzehCwyh7hKUKlWLgE6soDdW/T6JPePC16exzFDNdZHXRj7lqv75yMWJCkBY0pBtWicMLinb4ni6QRyg==",
+      "dev": true,
       "requires": {
         "lodash": "4.17.5"
       }
@@ -7077,6 +7078,15 @@
         "tough-cookie": "2.3.4"
       }
     },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "2.0.0",
+        "semver": "5.5.0"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7088,15 +7098,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
-    },
-    "require_optional": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-      "requires": {
-        "resolve-from": "2.0.0",
-        "semver": "5.5.0"
-      }
     },
     "resolve": {
       "version": "1.1.7",
@@ -7706,6 +7707,14 @@
         "duplexer": "0.1.1"
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -7724,14 +7733,6 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,6 @@
     "express": "^4.16.2",
     "express-session": "^1.15.6",
     "graphql": "^0.13.1",
-    "graphql-import": "^0.5.0",
     "graphql-server-express": "^1.3.2",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tag": "^2.8.0",
@@ -34,6 +33,7 @@
     "apollo-client": "^2.2.6",
     "apollo-link-schema": "^1.0.6",
     "babel-cli": "7.0.0-beta.3",
+    "graphql-import": "^0.6.0",
     "jest": "^22.4.2",
     "nodemon": "^1.17.3",
     "tingodb-promise": "0.0.2"

--- a/server/src/api/graphql/schema.graphql
+++ b/server/src/api/graphql/schema.graphql
@@ -1,6 +1,6 @@
-# import * from "lists/lists.graphql"
-# import * from "todoItems/todoItems.graphql"
-# import * from "users/users.graphql"
+# import Query.*, Mutation.*, Subscription.*, * from "lists/lists.graphql"
+# import Query.*, Mutation.*, * from "todoItems/todoItems.graphql"
+# import Query.*, Mutation.*, * from "users/users.graphql"
 
 schema {
     query: Query


### PR DESCRIPTION
Wildcard imports in graphql-import@0.6.0 don't include Query, Mutation, and Subscription as per [link](https://github.com/prismagraphql/graphql-import/pull/176). More granular import statements are now required.